### PR TITLE
Added red color on hovering the row for inactive users

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -33,3 +33,17 @@ if(window.location.pathname=="/"){
         }
     })
 }
+
+$('tbody tr').each(function () {
+    const statusCell = $(this).find('td:eq(4)'); 
+    const status = statusCell.text().trim();
+    if (status == 'Inactive')
+    {
+        // for hovering actions use moseover and mouseset
+        $(this).on('mouseover', function () {
+            $(this).css('background-color', 'red');
+          }).on('mouseout', function () {
+            $(this).css('background-color', ''); 
+          });
+    }
+  });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I have made the change of color to red when the user status is inactive else it remains to red

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- (https://github.com/ContriHUB/User-management-system/issues/3)-->

Fixes # (issue)

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Motivation and Context

<!--- enhances the user interaction-->

## How Has This Been Tested?

<!--- I have tested it on my local pc by running it on local server -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!-- Ignore if not relevant for you -->

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have registered myself at [Contrihub website](https://sac.mnnit.ac.in/contrihub).
- [x] My code follows the code style of this project.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK: